### PR TITLE
Use absolute imports for py3 forward compatibility

### DIFF
--- a/aws-experiment-launch/utils/launch_template.py
+++ b/aws-experiment-launch/utils/launch_template.py
@@ -1,4 +1,6 @@
-import utils
+from __future__ import absolute_import
+
+from . import utils
 
 
 def get_launch_template_name(region_number):

--- a/aws-experiment-launch/utils/spot_fleet.py
+++ b/aws-experiment-launch/utils/spot_fleet.py
@@ -1,5 +1,7 @@
-import utils
-import mylogger
+from __future__ import absolute_import
+
+from . import utils
+from . import mylogger
 
 LOGGER = mylogger.getLogger(__file__)
 

--- a/aws-experiment-launch/utils/utils_test.py
+++ b/aws-experiment-launch/utils/utils_test.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 import unittest
 
-from utils import generate_distribution_config
+from .utils import generate_distribution_config
 
 class TestCreateAndDeploy(unittest.TestCase):
 


### PR DESCRIPTION
Same-package imports must be done as relative imports or fully qualified
imports in Python 3.  This commit uses relative imports.