### PR TITLE
Make userdata script work for GCP too

### DIFF
--- a/aws-experiment-launch/configs/userdata-soldier-http.sh
+++ b/aws-experiment-launch/configs/userdata-soldier-http.sh
@@ -11,7 +11,10 @@ FOLDER=leo/
 TESTBIN=( txgen soldier benchmark commander go-commander.sh )
 
 for bin in "${TESTBIN[@]}"; do
-   curl http://${BUCKET}.s3.amazonaws.com/${FOLDER}${bin} -o ${bin}
+   while ! curl http://${BUCKET}.s3.amazonaws.com/${FOLDER}${bin} -o ${bin}
+   do
+      sleep 1
+   done
    chmod +x ${bin}
 done
 

--- a/aws-experiment-launch/configs/userdata-soldier-http.sh
+++ b/aws-experiment-launch/configs/userdata-soldier-http.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exec > /var/log/harmony-benchmark-startup.out 2>&1
+
 mkdir -p /home/ec2-user
 cd /home/ec2-user
 

--- a/aws-experiment-launch/configs/userdata-soldier-http.sh
+++ b/aws-experiment-launch/configs/userdata-soldier-http.sh
@@ -76,7 +76,6 @@ azure)
 	;;
 gcp)
 	PUB_IP=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip')
-	yum install -y psmisc	# for fuser
 	;;
 *)
 	err "Unknown VM flavor.  Instance is unusable."
@@ -90,10 +89,6 @@ msg "Public IP: ${PUB_IP}"
 msg "Soldier port: ${SOLDIER_PORT}"
 msg "Node port: ${NODE_PORT}"
 msg "Soldier log: ${SOLDIER_LOG}"
-
-msg "Killing existing soldier/node..."
-fuser -k -n tcp $SOLDIER_PORT
-fuser -k -n tcp $NODE_PORT
 
 msg "Running soldier..."
 ./soldier -ip $PUB_IP -port $NODE_PORT -http > "${SOLDIER_LOG}" 2>&1 &

--- a/aws-experiment-launch/configs/userdata-soldier.sh
+++ b/aws-experiment-launch/configs/userdata-soldier.sh
@@ -76,7 +76,6 @@ azure)
 	;;
 gcp)
 	PUB_IP=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip')
-	yum install -y psmisc	# for fuser
 	;;
 *)
 	err "Unknown VM flavor.  Instance is unusable."
@@ -90,10 +89,6 @@ msg "Public IP: ${PUB_IP}"
 msg "Soldier port: ${SOLDIER_PORT}"
 msg "Node port: ${NODE_PORT}"
 msg "Soldier log: ${SOLDIER_LOG}"
-
-msg "Killing existing soldier/node..."
-fuser -k -n tcp $SOLDIER_PORT
-fuser -k -n tcp $NODE_PORT
 
 msg "Running soldier..."
 ./soldier -ip $PUB_IP -port $NODE_PORT > "${SOLDIER_LOG}" 2>&1 &

--- a/aws-experiment-launch/configs/userdata-soldier.sh
+++ b/aws-experiment-launch/configs/userdata-soldier.sh
@@ -2,8 +2,12 @@
 
 exec > /var/log/harmony-benchmark-startup.out 2>&1
 
-mkdir -p /home/ec2-user
-cd /home/ec2-user/
+progname="${0##*/}"
+msg() { case $# in 0);; *) echo "${progname}: $*" >&2;; esac; }
+err() { msg ERROR: "$@"; exit 1; }
+
+mkdir -p /home/ec2-user/
+cd /home/ec2-user
 
 BUCKET=unique-bucket-bin
 FOLDER=ec2-user/
@@ -11,10 +15,17 @@ FOLDER=ec2-user/
 TESTBIN=( txgen soldier benchmark commander go-commander.sh )
 
 for bin in "${TESTBIN[@]}"; do
-   curl http://${BUCKET}.s3.amazonaws.com/${FOLDER}${bin} -o ${bin}
+   url="http://${BUCKET}.s3.amazonaws.com/${FOLDER}${bin}"
+   msg "Downloading ${bin} from ${url}..."
+   while ! curl "${url}" -o ${bin}
+   do
+      msg "Download from ${url} failed; see above for errors.  Retrying..."
+      sleep 1
+   done
    chmod +x ${bin}
 done
 
+msg "Tweaking networking sysctls..."
 sysctl -w net.core.somaxconn=1024
 sysctl -w net.core.netdev_max_backlog=65536
 sysctl -w net.ipv4.tcp_tw_reuse=1
@@ -22,6 +33,7 @@ sysctl -w net.ipv4.tcp_rmem='4096 65536 16777216'
 sysctl -w net.ipv4.tcp_wmem='4096 65536 16777216'
 sysctl -w net.ipv4.tcp_mem='65536 131072 262144'
 
+msg "Setting rlimits..."
 echo "* soft     nproc          65535" | sudo tee -a /etc/security/limits.conf
 echo "* hard     nproc          65535" | sudo tee -a /etc/security/limits.conf
 echo "* soft     nofile         65535" | sudo tee -a /etc/security/limits.conf
@@ -52,7 +64,10 @@ get_vm_flavor() {
 	fi
 }
 
-case $(get_vm_flavor) in
+vm_flavor=$(get_vm_flavor)
+msg "Current VM flavor: ${vm_flavor}"
+
+case "${vm_flavor}" in
 aws)
 	PUB_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
 	;;
@@ -64,17 +79,23 @@ gcp)
 	yum install -y psmisc	# for fuser
 	;;
 *)
-	echo "ERROR: unknown VM flavor.  Instance is unusable."
-	exit
+	err "Unknown VM flavor.  Instance is unusable."
 	;;
 esac
 
 NODE_PORT=9000
 SOLDIER_PORT=1$NODE_PORT
+SOLDIER_LOG="$(pwd)/soldier-${PUB_IP}.log"
+msg "Public IP: ${PUB_IP}"
+msg "Soldier port: ${SOLDIER_PORT}"
+msg "Node port: ${NODE_PORT}"
+msg "Soldier log: ${SOLDIER_LOG}"
 
-# Kill existing soldier/node
+msg "Killing existing soldier/node..."
 fuser -k -n tcp $SOLDIER_PORT
 fuser -k -n tcp $NODE_PORT
 
-# Run soldier
-./soldier -ip $PUB_IP -port $NODE_PORT > soldier-${PUB_IP}.log 2>&1 &
+msg "Running soldier..."
+./soldier -ip $PUB_IP -port $NODE_PORT > "${SOLDIER_LOG}" 2>&1 &
+
+msg "Finished.  Soldier is running (PID $!)."

--- a/aws-experiment-launch/configs/userdata-soldier.sh
+++ b/aws-experiment-launch/configs/userdata-soldier.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exec > /var/log/harmony-benchmark-startup.out 2>&1
+
 mkdir -p /home/ec2-user
 cd /home/ec2-user/
 


### PR DESCRIPTION
Other improvements:

* Failed cURL downloads of binaries are retried (downloads from GCP are especially flaky);
* Script output is now captured in `/var/log/harmony-benchmark-startup.out` for later diagnosis;
* Script output includes useful info such as autodetected cloud type and public IP.