### PR TITLE
Add ek-push config

### DIFF
--- a/configs/benchmark-ek-push.json
+++ b/configs/benchmark-ek-push.json
@@ -1,0 +1,72 @@
+{
+  "description": "aws 50 nodes on 1 shard, run 300 seconds",
+  "client": {
+    "num_vm": 1,
+    "type": "t3.medium",
+    "regions": "iad"
+  },
+  "leader": {
+    "num_vm": 1,
+    "type": "t3.medium",
+    "regions": "iad"
+  },
+  "bootnode": {
+     "enable": true,
+     "server": "54.213.43.194",
+     "name": "b2.harmony.one",
+     "port": 9869,
+     "user": "ec2-user",
+     "key": "oregon-key-benchmark.pem"
+  },
+  "beacon": {
+     "enable": false,
+     "server": "54.183.5.66",
+     "port": 9997,
+     "user": "ec2-user",
+     "key": "california-key-benchmark.pem"
+  },
+  "azure": {
+    "num_vm": 0,
+    "regions": [
+      "eastus",
+      "westeurope",
+      "southeastasia"
+    ]
+  },
+  "benchmark": {
+    "shards": 1,
+    "duration": 300,
+    "dashboard": false,
+    "crosstx": 30,
+    "attacked_mode": 0,
+    "minpeer": 24
+  },
+  "logs": {
+    "leader": true,
+    "client": true,
+    "validator": true,
+    "soldier": true,
+    "db": true
+  },
+  "dashboard": {
+    "server": "34.222.41.95",
+    "port": 3000,
+    "reset": "false"
+  },
+  "explorer": {
+    "server": "34.222.41.95",
+    "port": 4000,
+    "reset": "false"
+  },
+  "txgen": {
+     "enable": "true",
+     "ip": "myip",
+     "port": 8000
+  },
+  "parallel": 100,
+  "userdata": "userdata-soldier-http.sh",
+  "flow": {
+     "wait_for_launch": 30
+  },
+  "libp2p": true
+}

--- a/configs/launch-ek-push.json
+++ b/configs/launch-ek-push.json
@@ -1,0 +1,15 @@
+{
+   "launch": [
+      {
+         "region": "iad",
+         "type": "t3.micro",
+         "ondemand": 3,
+         "spot": 30
+      }
+   ],
+   "userdata": {
+      "name": "http",
+      "file": "userdata-soldier-http.sh.aws"
+   },
+   "batch": 100
+}


### PR DESCRIPTION
SSIA.

The real diff (`git diff --find-copies-harder harmony-one/master..add_ek_push_config`) is:

```diff
diff --git a/configs/benchmark-pr.json b/configs/benchmark-ek-push.json
similarity index 98%
copy from configs/benchmark-pr.json
copy to configs/benchmark-ek-push.json
index 1cffed2..25ae17c 100644
--- a/configs/benchmark-pr.json
+++ b/configs/benchmark-ek-push.json
@@ -14,7 +14,7 @@
      "enable": true,
      "server": "54.213.43.194",
      "name": "b2.harmony.one",
-     "port": 9870,
+     "port": 9869,
      "user": "ec2-user",
      "key": "oregon-key-benchmark.pem"
   },
diff --git a/configs/launch-pr.json b/configs/launch-ek-push.json
similarity index 100%
copy from configs/launch-pr.json
copy to configs/launch-ek-push.json
```