### PR TITLE
Store latest log link

### DIFF
--- a/pipeline/go.sh
+++ b/pipeline/go.sh
@@ -286,9 +286,10 @@ function do_sync_logs
    MONTH=${TS:4:2}
    DAY=${TS:6:2}
    TIME=${TS:9:6}
-   aws s3 sync logs/$TS s3://harmony-benchmark/logs/$YEAR/$MONTH/$DAY/$TIME 2>&1 > /dev/null
-   S3URL=s3://harmony-benchmark/logs/$YEAR/$MONTH/$DAY/$TIME
-   echo s3://harmony-benchmark/logs/$YEAR/$MONTH/$DAY/$TIME
+   TSDIR="$YEAR/$MONTH/$DAY/$TIME"
+   aws s3 sync logs/$TS s3://harmony-benchmark/logs/$TSDIR 2>&1 > /dev/null
+   S3URL=s3://harmony-benchmark/logs/$TSDIR
+   echo s3://harmony-benchmark/logs/$TSDIR
    expense s3_sync
 }
 

--- a/pipeline/go.sh
+++ b/pipeline/go.sh
@@ -463,18 +463,19 @@ function do_all
 }
 
 ######### VARIABLES #########
+: ${WHOAMI="${USER}"}
 PROFILE=tiny
 PROFILES=( $(ls $CONFIG_DIR/benchmark-*.json | sed -e "s,$CONFIG_DIR/benchmark-,,g" -e 's/.json//g') )
 SESSION_FILE=$CONFIG_DIR/profile-${PROFILE}.json
 BENCHMARK_FILE=$CONFIG_DIR/benchmark-${PROFILE}.json
 BUCKET=unique-bucket-bin
-USERID=${WHOAMI:-$USER}
+USERID=${WHOAMI}
 FOLDER=$USERID
 USERDATA=$CONFIG_DIR/userdata-soldier-http.sh
 VERBOSE=
 THEPWD=$(pwd)
 KEEP=false
-TAG=${WHOAMI:-USER}
+TAG=${WHOAMI}
 TXGEN=true
 WALLET=false
 

--- a/pipeline/go.sh
+++ b/pipeline/go.sh
@@ -290,6 +290,7 @@ function do_sync_logs
    aws s3 sync logs/$TS s3://harmony-benchmark/logs/$TSDIR 2>&1 > /dev/null
    S3URL=s3://harmony-benchmark/logs/$TSDIR
    echo $S3URL
+   echo "$TSDIR" | aws s3 cp - s3://harmony-benchmark/logs/latest-${USERID}-${PROFILE}.txt
    expense s3_sync
 }
 

--- a/pipeline/go.sh
+++ b/pipeline/go.sh
@@ -290,7 +290,7 @@ function do_sync_logs
    aws s3 sync logs/$TS s3://harmony-benchmark/logs/$TSDIR 2>&1 > /dev/null
    S3URL=s3://harmony-benchmark/logs/$TSDIR
    echo $S3URL
-   echo "$TSDIR" | aws s3 cp - s3://harmony-benchmark/logs/latest-${USERID}-${PROFILE}.txt
+   echo "$TSDIR" | aws s3 cp - s3://harmony-benchmark/logs/latest-${WHOAMI}-${PROFILE}.txt
    expense s3_sync
 }
 

--- a/pipeline/go.sh
+++ b/pipeline/go.sh
@@ -289,7 +289,7 @@ function do_sync_logs
    TSDIR="$YEAR/$MONTH/$DAY/$TIME"
    aws s3 sync logs/$TS s3://harmony-benchmark/logs/$TSDIR 2>&1 > /dev/null
    S3URL=s3://harmony-benchmark/logs/$TSDIR
-   echo s3://harmony-benchmark/logs/$TSDIR
+   echo $S3URL
    expense s3_sync
 }
 

--- a/pipeline/go.sh
+++ b/pipeline/go.sh
@@ -464,6 +464,7 @@ function do_all
 
 ######### VARIABLES #########
 : ${WHOAMI="${USER}"}
+export WHOAMI
 PROFILE=tiny
 PROFILES=( $(ls $CONFIG_DIR/benchmark-*.json | sed -e "s,$CONFIG_DIR/benchmark-,,g" -e 's/.json//g') )
 SESSION_FILE=$CONFIG_DIR/profile-${PROFILE}.json


### PR DESCRIPTION
Store latest `$TSDIR` for owner/profile info into S3

This is so that external tools can autodetect the current log directory.

The URL is `s3://harmony-benchmark/logs/latest-${WHOAMI}-${PROFILE}.txt` (example: `s3://harmony-benchmark/logs/latest-drum-drum.txt`).