### PR TITLE
Do not use DNS for initial bootstrap

### DIFF
--- a/pipeline/run_benchmark.sh
+++ b/pipeline/run_benchmark.sh
@@ -286,7 +286,7 @@ EOT
             "${LOGDIR}/${cmd}/${cmd}-"*".json"
          do
             $JQ '.benchmarkArgs += "'"${dns_zone}"'"' < "${initfile}" > "${intifile}.new"
-            mv "${initfile}.new" "${initfile}"
+            mv -f "${initfile}.new" "${initfile}"
          done
          ;;
       esac

--- a/pipeline/run_benchmark.sh
+++ b/pipeline/run_benchmark.sh
@@ -114,15 +114,13 @@ function do_simple_cmd
       then
          benchmarkArgs+=" -log_conn"
       fi
-      case "${dns_zone+set}" in
-      set)
-         benchmarkArgs+=" -dns_zone=${dns_zone}"
-         ;;
-      esac
       txgenArgs="-duration -1 -cross_shard_ratio $CROSSTX $BOOTNODES"
       if [ -n "$DASHBOARD" ]; then
          benchmarkArgs+=" $DASHBOARD"
       fi
+      # Disable DNS for the initial launch
+      # This must be the last benchmark arg so that dns_zone append will work later
+      benchmarkArgs+=" -dns_zone="
       if [ "$CLIENT" == "true" ]; then
          CLIENT_JSON=',"role":"client"'
       fi
@@ -278,6 +276,22 @@ EOT
 
    fi
 
+   # add DNS zone option to init json for later restarts
+   case "${cmd}" in
+   init)
+      case "${dns_zone+set}" in
+      set)
+         for initfile in \
+            "${LOGDIR}/${cmd}/leader.${cmd}-"*".json" \
+            "${LOGDIR}/${cmd}/${cmd}-"*".json"
+         do
+            $JQ '.benchmarkArgs += "'"${dns_zone}"'"' < "${initfile}" > "${intifile}.new"
+            mv "${initfile}.new" "${initfile}"
+         done
+         ;;
+      esac
+      ;;
+   esac
 }
 
 function do_update


### PR DESCRIPTION
Add `-dns_zone=XXX` to `benchmarkArgs` after the initial bootstrapping is complete.  This is because, when the nodes are fired up for the first time, the DNS update has not occurred yet, and the DNS records will likely contain either no or even stale addresses.