### PR TITLE
add profile for double signing netowrk provision

### DIFF
--- a/configs/benchmark-dsign.json
+++ b/configs/benchmark-dsign.json
@@ -1,0 +1,108 @@
+{
+  "description": "aws 30 nodes on 3 shard in one region",
+  "client": {
+    "num_vm": 0,
+    "type": "t3.medium",
+    "regions": "iad"
+  },
+  "leader": {
+    "num_vm": 3,
+    "type": "t3.small",
+    "regions": "iad",
+    "protection": false,
+    "root": 15
+  },
+  "explorer_node": {
+    "num_vm": 3,
+    "type": "t3.small",
+    "regions": "iad",
+    "root": 25,
+    "protection": false
+  },
+  "bootnode": {
+     "enable": true,
+     "server": "52.40.84.2",
+     "name": "b6.harmony.one",
+     "port": 9890,
+     "user": "ec2-user",
+     "key": "oregon-key-benchmark.pem",
+     "p2pkey": "b2-9870.key",
+     "log_conn": false
+  },
+  "bootnode1": {
+     "enable": true,
+     "server": "54.86.126.90",
+     "name": "b5.harmony.one",
+     "port": 9890,
+     "user": "ec2-user",
+     "key": "virginia-key-benchmark.pem",
+     "p2pkey": "b1-9870.key",
+     "log_conn": false
+  },
+  "azure": {
+    "num_vm": 0,
+    "regions": [
+      "eastus",
+      "westeurope",
+      "southeastasia"
+    ]
+  },
+  "benchmark": {
+    "shards": 3,
+    "duration": 120,
+    "dashboard": false,
+    "crosstx": 30,
+    "attacked_mode": 0,
+    "peer_per_shard": 10,
+    "minpeer": 6,
+    "log_conn": false,
+    "even_shard": true,
+    "init_retry": false,
+    "commit_delay": "2s",
+    "network_type": "testnet",
+    "bls": true
+  },
+  "logs": {
+    "leader": true,
+    "client": false,
+    "validator": true,
+    "soldier": true,
+    "db": false
+  },
+  "dashboard": {
+    "name": "1.harmony.one",
+    "port": 3000,
+    "reset": "false"
+  },
+  "explorer": {
+    "name": "explorer.harmony.one",
+    "port": 4444,
+    "reset": "false"
+  },
+  "explorer2": {
+    "name": "34.220.94.30",
+    "port": 4444,
+    "reset": "false"
+  },
+  "txgen": {
+     "enable": "false",
+     "ip": "myip",
+     "port": 8000
+  },
+  "parallel": 50,
+  "userdata": "userdata-soldier-http.sh",
+  "flow": {
+     "wait_for_launch": 60,
+     "reserved_account": "",
+     "rpczone": "os",
+     "rpcnode": 2
+  },
+  "bls": {
+     "pass": "blsnopass.txt",
+     "bucket": "harmony-secret-keys",
+     "folder": "bls-test",
+     "keyfile": "blskey-test.txt"
+  },
+  "genesis": "genesis.txt",
+  "libp2p": true
+}

--- a/configs/launch-dsign.json
+++ b/configs/launch-dsign.json
@@ -1,0 +1,17 @@
+{
+   "launch": [
+      {
+         "region": "iad",
+         "type": "t3.small",
+         "ondemand": 0,
+         "spot": 18,
+         "protection": false,
+         "root": 15
+      }
+   ],
+   "userdata": {
+      "name": "http",
+      "file": "userdata-soldier-http.sh.aws"
+   },
+   "batch": 100
+}


### PR DESCRIPTION
create a network for double signing network provision; port 9890 has been created on both bootnode servers.