### PR TITLE
ensure restart_node works for DO droplet

### DIFF
--- a/pipeline/restart_node.sh
+++ b/pipeline/restart_node.sh
@@ -289,7 +289,8 @@ get_logfile() {
 		') || return $?
 		;;
 	*)
-		logfiledir='latest'
+		# for DO, its proper path is: /root/do-user/latest
+		logfiledir="${latest:-/root/do-user/latest}"
 		;;
 	esac
 	case "${node_type}" in


### PR DESCRIPTION
restart_node perviously didn't work for a DO droplet, main reason is that the log folder is located differently for a node running in aws or gcp.

