### PR TITLE
Make STN in sfo & pdx, change instance to m5a.large

### DIFF
--- a/configs/benchmark-stn.json
+++ b/configs/benchmark-stn.json
@@ -2,20 +2,20 @@
   "description": "aws 160 nodes, 4 shards",
   "client": {
     "num_vm": 0,
-    "type": "m5a.xlarge",
-    "regions": "cmh"
+    "type": "m5a.large",
+    "regions": "sfo,pdx"
   },
   "leader": {
     "num_vm": 1,
     "type": "m5a.xlarge",
-    "regions": "cmh,pdx",
+    "regions": "sfo,pdx",
     "protection": false,
     "root": 15
   },
   "explorer_node": {
     "num_vm": 1,
     "type": "m5a.xlarge",
-    "regions": "cmh,pdx",
+    "regions": "sfo,pdx",
     "root": 25,
     "protection": false
   },

--- a/configs/launch-stn.json
+++ b/configs/launch-stn.json
@@ -1,8 +1,8 @@
 {
    "launch": [
         {
-            "region": "cmh",
-            "type": "m5a.xlarge",
+            "region": "sfo",
+            "type": "m5a.large",
             "ondemand": 0,
             "spot": 9,
             "protection": false,
@@ -10,7 +10,7 @@
         },
         {
             "region": "pdx",
-            "type": "m5a.xlarge",
+            "type": "m5a.large",
             "ondemand": 0,
             "spot": 9,
             "protection": false,


### PR DESCRIPTION
cmh region had issue with the explorer node. Once I changed the region to sfo, it worked again. Unsure why. 