### PR TITLE
[pipeline] Add options to fund.sh for hard reset

### DIFF
--- a/pipeline/fund.sh
+++ b/pipeline/fund.sh
@@ -5,9 +5,41 @@ if [ -z "${HMY_PROFILE}" ]; then
   exit
 fi
 
+csv_source="https://docs.google.com/spreadsheets/d/e/2PACX-1vTUUOCAuSgP8TcA1xWY5AbxaMO7OSowYgdvaHpeMQudAZkHkJrf2sGE6TZ0hIbcy20qpZHmlC8HhCw1/pub?gid=0&single=true&output=csv"
 csv_file="fund-${HMY_PROFILE}.csv"
 
+unset OPTARG opt clear force shards
+clear=false
+force=false
+shards="0"
+while getopts :cfs: opt
+do
+   case "${opt}" in
+    c) clear=true ;;
+    f) force=true ;;
+    s) shards="${OPTARG}" ;;
+    *) echo "
+        Funding script according to harmony.one/keys2
+
+        Options:
+        -c                      Clear the old funding logs before starting the funding process. 
+        -f                      Force funding without any checks.
+        -s shards CSV string    Specify shards to fund as a CSV string. (default: ${shards})
+    "
+    exit ;;
+   esac
+done
+
 rm -rf ./bin  # Clear existing CLI, assuption made of where fund.py stores CLI binary.
-echo "Getting funding information from harmony.one/keys2"
-curl -o "${csv_file}" 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTUUOCAuSgP8TcA1xWY5AbxaMO7OSowYgdvaHpeMQudAZkHkJrf2sGE6TZ0hIbcy20qpZHmlC8HhCw1/pub?gid=0&single=true&output=csv'
-python3 -u fund.py --from_csv "${csv_file}" --shards "0" --yes
+if [ "${clear}" = true ]; then
+    echo "[!] clearing old funding logs..."
+    rm ./logs/${HMY_PROFILE}/funding.json
+fi
+echo "[!] getting funding information from harmony.one/keys2"
+curl -o "${csv_file}" "${csv_source}" -s > /dev/null
+if [ "${force}" = true ]; then
+    echo "[!] force funding..."
+    python3 -u fund.py --from_csv "${csv_file}" --shards "${shards}" --yes --force
+else
+    python3 -u fund.py --from_csv "${csv_file}" --shards "${shards}" --yes 
+fi


### PR DESCRIPTION
These options are needed for funding on hard resets.

For a hard reset (without reiniting a network) one funds accounts with the following command:
```
./fund.sh -c
```