### PR TITLE
[systemd] capture stderr in harmony.err

### DIFF
--- a/tf/aws.1/files/harmony-mk.service
+++ b/tf/aws.1/files/harmony-mk.service
@@ -10,6 +10,9 @@ RestartSec=1
 User=ec2-user
 WorkingDirectory=/home/ec2-user
 ExecStart=/home/ec2-user/node.sh -1 -S -P -p /home/ec2-user/bls.pass -M -D
+StandardError=file:/home/ec2-user/harmony.err
+LimitNOFILE=65536
+LimitNPROC=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/tf/do/files/harmony.service
+++ b/tf/do/files/harmony.service
@@ -9,6 +9,9 @@ User=root
 WorkingDirectory=/root
 ExecStart=bash /root/node.sh -1 -p /root/bls.pass -k /root/bls.key -P
 Restart=always
+StandardError=file:/root/harmony.err
+LimitNOFILE=65536
+LimitNPROC=65536
 
 [Install]
 WantedBy=multi-user.target 

--- a/tf/gcp/files/harmony-mk.service
+++ b/tf/gcp/files/harmony-mk.service
@@ -9,6 +9,9 @@ User=gce-user
 WorkingDirectory=/home/gce-user
 ExecStart=bash /home/gce-user/node.sh -1 -S -p /home/gce-user/bls.pass -M -P -D
 Restart=always
+StandardError=file:/home/gce-user/harmony.err
+LimitNOFILE=65536
+LimitNPROC=65536
 
 [Install]
 WantedBy=multi-user.target 

--- a/tools/harmony.service.template
+++ b/tools/harmony.service.template
@@ -10,6 +10,9 @@ RestartSec=1
 User=%%USER%%
 WorkingDirectory=%%HOME%% 
 ExecStart=%%HOME%%/node.sh -1 -S -P -M -D -N %%NETWORK%% -p %%HOME%%/%%BLSPASS%% -T %%NODETYPE%% %%EXTRA%%
+StandardError=file:%%HOME%%/harmony.err
+LimitNOFILE=65536
+LimitNPROC=65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
this change can capture stack trace of harmony node
in harmony.err file when the node is running under systemd service.

set limit of open files to 64k
set limit of running processes to 64k

Signed-off-by: Leo Chen <leo@harmony.one>