### PR TITLE
Fix broken static binary download

### DIFF
--- a/pipeline/restart_node.sh
+++ b/pipeline/restart_node.sh
@@ -380,12 +380,12 @@ fetch_binaries() {
 	*)
 		rn_info "fetching upgrade binaries"
 		node_ssh "${ip}" "
-			rm -rf ${dest_folder}/*
+			rm -rf ${dest_folder}
 		"
 		# only sync harmony static binary
 		if ${static_build}; then
 			node_ssh "${ip}" "
-				aws s3 cp $(shell_quote "${s3_folder}/static/harmony") ${dest_folder}
+				aws s3 cp $(shell_quote "${s3_folder}/static/harmony") ${dest_folder}/
 			"
 		else
 			node_ssh "${ip}" "


### PR DESCRIPTION
The static binary should be downloaded to the staging folder - but right now it's occasionally downloaded as a file named "staging".

Previous rm -rf also only tried to remove staging/* which wouldn't remove the invalid file if it was downloaded - which broke any ensuing attempts with trying to reinstall the static binary