### PR TITLE
STN updates - fund.sh & hard-reset.sh

### DIFF
--- a/pipeline/fund.sh
+++ b/pipeline/fund.sh
@@ -5,19 +5,17 @@ if [ -z "${HMY_PROFILE}" ]; then
   exit
 fi
 
-csv_source="https://docs.google.com/spreadsheets/d/e/2PACX-1vTUUOCAuSgP8TcA1xWY5AbxaMO7OSowYgdvaHpeMQudAZkHkJrf2sGE6TZ0hIbcy20qpZHmlC8HhCw1/pub?gid=0&single=true&output=csv"
-csv_file="fund-${HMY_PROFILE}.csv"
-
 unset OPTARG opt clear force shards
 clear=false
 force=false
 shards="0"
-while getopts :cfs: opt
+while getopts :cfs:u: opt
 do
    case "${opt}" in
     c) clear=true ;;
     f) force=true ;;
     s) shards="${OPTARG}" ;;
+    u) csv_source="${OPTARG}" ;;
     *) echo "
         Funding script according to harmony.one/keys2
 
@@ -25,17 +23,29 @@ do
         -c                      Clear the old funding logs before starting the funding process. 
         -f                      Force funding without any checks.
         -s shards CSV string    Specify shards to fund as a CSV string. (default: ${shards})
+        -u URL                  Url to the spreadsheet/CSV file that will be used as the source for funding accounts
     "
     exit ;;
    esac
 done
 
+csv_file="fund-${HMY_PROFILE}.csv"
+
+if [ -z "${csv_source}" ]; then
+  csv_source="https://docs.google.com/spreadsheets/d/e/2PACX-1vTUUOCAuSgP8TcA1xWY5AbxaMO7OSowYgdvaHpeMQudAZkHkJrf2sGE6TZ0hIbcy20qpZHmlC8HhCw1/pub?gid=0&single=true&output=csv"
+  csv_name="harmony.one/keys2"
+fi
+
+if [ -z "${csv_name}" ]; then
+  csv_name=$csv_source
+fi
+
 rm -rf ./bin  # Clear existing CLI, assuption made of where fund.py stores CLI binary.
 if [ "${clear}" = true ]; then
     echo "[!] clearing old funding logs..."
-    rm ./logs/${HMY_PROFILE}/funding.json
+    rm -rf ./logs/${HMY_PROFILE}/funding.json
 fi
-echo "[!] getting funding information from harmony.one/keys2"
+echo "[!] getting funding information from ${csv_name}"
 curl -o "${csv_file}" "${csv_source}" -s > /dev/null
 if [ "${force}" = true ]; then
     echo "[!] force funding..."


### PR DESCRIPTION
[fund.sh] - add support for specifying a custom URL to fetch CSV data to use for funding addresses

[hard-reset.sh] - add support for starting regression tests and performing additional STN funding to fund test wallets & Jenkins regression tests wallet. This PR also makes the wait time before funding starts configurable (default is still 10 minutes).

All Jenkins related interactions will only work if you `export JENKINS_CREDENTIALS` before you run the script, e.g: `export JENKINS_CREDENTIALS=USER:TOKEN`