### PR TITLE
[#293]support differentiate validator or explorer node

### DIFF
--- a/ansible/playbooks/roles/node/files/harmony.explorer.service
+++ b/ansible/playbooks/roles/node/files/harmony.explorer.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=harmony service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=root
+WorkingDirectory=/root
+ExecStart=/root/node.sh -N staking -1 -P -p /root/.hmy/blskeys/bls.pass -M -D -T explorer -i 0 -A
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/playbooks/roles/node/tasks/main.yml
+++ b/ansible/playbooks/roles/node/tasks/main.yml
@@ -47,30 +47,37 @@
   debug:
     msg: Ver={{ Ver }}
 
-- name: copy harmony service files
+- name: copy validator node harmony service files
   copy:
     src: harmony.service
     dest: /lib/systemd/system
+  when: "'exp' not in inventory"
 
-- name: check if we have specific harmony service file
-  local_action: stat path={{ role_path }}/files/{{ inventory_hostname }}/harmony.service
-  register: optional_harmony_service
-
-- name: upload specific harmony service
+- name: copy explorer node harmony service files
   copy:
-    src: "{{ inventory_hostname }}/harmony.service"
-    dest: /lib/systemd/system
-  when: optional_harmony_service.stat.exists
+    src: harmony.explorer.service
+    dest: /lib/systemd/system/harmony.service
+  when: "'exp' in inventory"
 
 - name: create .hmy/blskeys directory
   file:
     path: "{{ USER.home }}/.hmy/blskeys"
     state: directory
 
-- name: copy all bls keys and pass
+- name: copy all bls keys and pass for validator node
   copy:
     src: "{{ inventory_hostname }}/"
     dest: "{{ USER.home }}/.hmy/blskeys/"
+  when: "'exp' not in inventory"
+
+- name: create dummy bls key and pass for explorer node
+  file:
+    path: "{{ USER.home }}/.hmy/blskeys/{{ item }}"
+    state: touch
+  with_items:
+    - "bls.key"
+    - "bls.pass"
+  when: "'exp' in inventory"
 
 - name: enable harmony service
   systemd: 


### PR DESCRIPTION
regular validator node and explorer node are using different systemd service file, and different key setup.

regular validator nodes have multiple blskeys in .hmy/blskeys directory
explorer nodes just have a dummy key in .hmy/blskeys directory.

The node role should be able to differentiate regular nodes and explorer nodes using conditions of ansible.