### PR TITLE
[STN] New settings for a larger network with 4 shards and 300 nodes

### DIFF
--- a/configs/benchmark-stn.json
+++ b/configs/benchmark-stn.json
@@ -3,19 +3,19 @@
   "client": {
     "num_vm": 0,
     "type": "m5a.large",
-    "regions": "sfo,pdx"
+    "regions": "iad,sfo,cmh,pdx"
   },
   "leader": {
     "num_vm": 1,
     "type": "c5.large",
-    "regions": "sfo,pdx",
+    "regions": "iad,sfo,cmh,pdx",
     "protection": false,
     "root": 10
   },
   "explorer_node": {
     "num_vm": 1,
     "type": "c5.large",
-    "regions": "sfo,pdx",
+    "regions": "iad,sfo,cmh,pdx",
     "root": 25,
     "userdata": "userdata-systemd-static-exp.sh",
     "protection": false

--- a/configs/benchmark-stn.json
+++ b/configs/benchmark-stn.json
@@ -1,5 +1,5 @@
 {
-  "description": "aws 20 nodes, 2 shards",
+  "description": "aws 300 nodes, 4 shards",
   "client": {
     "num_vm": 0,
     "type": "m5a.large",
@@ -49,12 +49,12 @@
     ]
   },
   "benchmark": {
-    "shards": 2,
+    "shards": 4,
     "duration": 120,
     "dashboard": false,
-    "crosstx": 30,
+    "crosstx": 75,
     "attacked_mode": 0,
-    "peer_per_shard": 30,
+    "peer_per_shard": 75,
     "minpeer": 8,
     "log_conn": false,
     "even_shard": true,
@@ -106,7 +106,7 @@
   },
   "multikey": {
      "enable": true,
-     "keys_per_node": 3,
+     "keys_per_node": 1,
      "blskey_folder": ".hmy/blskeys"
   },
   "sentry1": {

--- a/configs/launch-stn.json
+++ b/configs/launch-stn.json
@@ -1,10 +1,26 @@
 {
    "launch": [
         {
+            "region": "iad",
+            "type": "t3.small",
+            "ondemand": 0,
+            "spot": 74,
+            "protection": false,
+            "root": 10
+        },
+        {
             "region": "sfo",
             "type": "t3.small",
             "ondemand": 0,
-            "spot": 9,
+            "spot": 74,
+            "protection": false,
+            "root": 10
+        },
+        {
+            "region": "cmh",
+            "type": "t3.small",
+            "ondemand": 0,
+            "spot": 74,
             "protection": false,
             "root": 10
         },
@@ -12,7 +28,7 @@
             "region": "pdx",
             "type": "t3.small",
             "ondemand": 0,
-            "spot": 9,
+            "spot": 74,
             "protection": false,
             "root": 10
         }


### PR DESCRIPTION
- 4 shards
- 300 total nodes
- 75 nodes per shard
- 1 bls key per node
- Regions: iad,sfo,cmh,pdx