### PR TITLE
[STN] only use 1 bls key per node

### DIFF
--- a/configs/benchmark-stn.json
+++ b/configs/benchmark-stn.json
@@ -106,7 +106,7 @@
   },
   "multikey": {
      "enable": true,
-     "keys_per_node": 3,
+     "keys_per_node": 1,
      "blskey_folder": ".hmy/blskeys"
   },
   "sentry1": {


### PR DESCRIPTION
Use 1 bls key per node temporarily for some tests on STN.