### PR TITLE
Snapshot Recovery Script

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,0 +1,6 @@
+pyhmy==20.5.5
+pexpect==4.8.0
+dnspython==1.16.0
+pagerduty-api==0.3
+botocore==1.16.20
+boto3==1.13.20

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -25,6 +25,7 @@ import sys
 import json
 import logging
 import traceback
+import re
 from multiprocessing.pool import ThreadPool
 
 import pexpect
@@ -43,35 +44,77 @@ from pyhmy import (
     blockchain,
 )
 
-
 script_directory = os.path.dirname(os.path.realpath(__file__))
-log = logging.getLogger("snapshot")
+log = logging.getLogger("snapshot_recovery")
+supported_networks = {"mainnet", "testnet", "staking", "partner", "stress"}
 beacon_chain_shard = 0
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description='Recover snapshot script to be ran from devops machine')
-    parser.add_argument("log_dir", type=str, help="Path to the log directory that contains the networks's shard?.txt files.")
-    parser.add_argument("--network", type=str, default="mainnet", help="Network type (default: mainnet)")
-    parser.add_argument("--shard", type=str, default="0,1,2,3",
-                        help="String in CSV format of shards to recover, default is '0,1,2,3'")
-    return parser.parse_args()
+_ip_regex = r"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
 
 
 def setup_logger(do_print=True):
     """
     Setup the logger for the snapshot package and returns the logger.
     """
-    logger = logging.getLogger("snapshot")
-    file_handler = logging.FileHandler(f"{script_directory}/snapshot.log")
+    log_file = f"{script_directory}/logs/{os.environ['HMY_PROFILE']}/snapshot_recovery.log"
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    logger = logging.getLogger("snapshot_recovery")
+    file_handler = logging.FileHandler(log_file)
     file_handler.setFormatter(
         logging.Formatter(f"(%(threadName)s)[%(asctime)s] %(message)s"))
     logger.addHandler(file_handler)
     if do_print:
         logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.setLevel(logging.DEBUG)
-    logger.debug("===== NEW SNAPSHOT =====")
+    logger.debug("===== NEW RECOVERY =====")
+    print(f"Logs saved to: {log_file}")
     return logger
+
+
+def interact(prompt, selection_list):
+    """
+    The single source of interaction with the console.
+    All interaction must confine to this function's requirement.
+
+    Prompt the user with `prompt` and an enumerated selection from a sorted `selection_list`.
+    Take in an integer, n, such that 0 <= n < len(`selection_list`).
+    If a `log` is provided, log the interaction and all errors at the info and error level respectively.
+
+    Keeps prompting user for input if input is invalid.
+    Prints user interaction before returning.
+
+    Note that all new lines from `prompt` and `selection_list` will be removed.
+
+    Returns n and corresponding selection string from `selection_list`.
+    """
+    input_prompt = f"{Typgpy.BOLD}Select option (number):{Typgpy.ENDC}\n> "
+    prompt, selection_list = prompt.replace("\n", ""), sorted(map(lambda e: e.replace("\n", ""), selection_list))
+    prompt_new_line_count = sum(1 for el in selection_list if el) + 3  # 1 for given prompt, 2 for input prompt
+    if prompt:
+        prompt_new_line_count += 1
+    printed_new_line_count = 0
+    print()
+
+    while True:
+        if prompt:
+            print(prompt)
+        for i, selection in enumerate(selection_list):
+            print(f"{Typgpy.BOLD}[{i}]{Typgpy.ENDC}\t{selection}")
+        user_input = input(input_prompt)
+        printed_new_line_count += prompt_new_line_count
+        try:
+            n = int(user_input)
+            if n >= len(selection_list):
+                continue
+            selection_report = f"{prompt} {Typgpy.BOLD}[{n}]{Typgpy.ENDC} {selection_list[n]}".strip()
+            for i in range(printed_new_line_count):
+                sys.stdout.write("\033[K")
+                if i + 1 < printed_new_line_count:
+                    sys.stdout.write("\033[F")
+            print(selection_report)
+            return selection_list[n]
+        except ValueError:
+            pass
 
 
 def select_snapshot():
@@ -129,8 +172,9 @@ def restart_and_check(ips_per_shard):
     """
     Main restart and verification function after DBs have been restored.
     """
-    if input(f"Restart shards {sorted(ips_per_shard.keys())}? [Y/n]\n> ").lower() not in {'yes', 'y'}:
+    if interact(f"Restart shards: {sorted(ips_per_shard.keys())}?", ["yes", "no"]) == "no":
         return
+
     threads = []
     post_check_pool = ThreadPool()
     for shard in ips_per_shard.keys():
@@ -168,31 +212,119 @@ def restart_and_check(ips_per_shard):
 
 def _get_ips_per_shard(args):
     """
-    Internal function to get the IPs per shard given a parsed args.
+    Internal function to get the IPs per shard given a parsed args, only used for main execution.
     """
-    return {}
+    log.debug("Loading IPs from given directory...")
+
+    ips_per_shard = {}
+    for file in os.listdir(args.logs_dir):
+        if re.match(r"shard[0-9]+.txt", file):
+            shard = int(file.replace("shard", "").replace(".txt", ""))
+            if shard in ips_per_shard.keys():
+                raise RuntimeError(f"Multiple IP files for shard {shard}")
+            with open(f"{args.logs_dir}/{file}", 'r', encoding='utf-8') as f:
+                ips = [line.strip() for line in f.readlines() if re.search(_ip_regex, line)]
+            if not ips:
+                raise RuntimeError(f"no VALID IP was loaded from file: '{args.logs_dir}/{file}'")
+            log.debug(f"Candidate IPs for shard {shard}: {ips}")
+
+            print(f"\nShard {Typgpy.HEADER}{shard}{Typgpy.ENDC} ips ({len(ips)}):")
+            for i, ip in enumerate(ips):
+                print(f"{i + 1}.\t{Typgpy.OKGREEN}{ip}{Typgpy.ENDC}")
+            choices = [
+                "Add all IPs",
+                "Select IPs to add (interactively)",
+                "Ignore"
+            ]
+            response = interact("", choices)
+
+            if response == choices[-1]:
+                log.debug(f"ignoring IPs from shard {shard}")
+                continue
+            if response == choices[0]:
+                log.debug(f"shard {shard} IPs: {ips}")
+                ips_per_shard[shard] = ips
+                continue
+            if response == choices[1]:
+                selected_ips = []
+                for ip in ips:
+                    prompt = f"Add {Typgpy.OKGREEN}{ip}{Typgpy.ENDC} for shard {Typgpy.HEADER}{shard}{Typgpy.ENDC}?"
+                    if interact(prompt, ["yes", "no"]) == "yes":
+                        selected_ips.append(ip)
+                if not selected_ips:
+                    msg = f"selected 0 IPs for shard {shard}, ignoring shard"
+                    log.debug(msg)
+                    continue
+                print(f"\nShard {Typgpy.HEADER}{shard}{Typgpy.ENDC} "
+                      f"{Typgpy.UNDERLINE}selected{Typgpy.ENDC} ips ({len(selected_ips)})")
+                for i, ip in enumerate(selected_ips):
+                    print(f"{i + 1}.\t{Typgpy.OKGREEN}{ip}{Typgpy.ENDC}")
+                if interact(f"Add ips for shard {Typgpy.HEADER}{shard}{Typgpy.ENDC}?", ["yes", "no"]) == "yes":
+                    log.debug(f"shard {shard} IPs: {selected_ips}")
+                    ips_per_shard[shard] = selected_ips
+                else:
+                    log.debug(f"ignoring IPs from shard {shard}")
+                continue
+
+    for shard in sorted(ips_per_shard.keys()):
+        print(f"Shard {Typgpy.HEADER}{shard}{Typgpy.ENDC} {Typgpy.UNDERLINE}loaded{Typgpy.ENDC} IPs:")
+        print('-' * 16)
+        for ip in sorted(ips_per_shard[shard]):
+            print(ip)
+        print()
+
+    final_report = "Added "
+    for k, v in ips_per_shard.items():
+        final_report += f"{len(v)} ips for shard {k}; "
+    log.debug(final_report)
+    return ips_per_shard
+
+
+def _assumption_check(args):
+    """
+    Internal function that checks the assumptions of the script, only used for main execution.
+    """
+    assert args.network in supported_networks, f"given network must be one of {supported_networks}"
+    assert os.path.isfile(f"{script_directory}/node_ssh.sh"), "script not in pipeline directory"
+    assert os.path.isdir(args.logs_dir), "given logs directory is not a directory"
+    if not any(f for f in os.listdir(args.logs_dir) if re.match(r"shard[0-9]+.txt", f)):
+        raise AssertionError(f"expected given logs directory, {args.logs_dir} to contain a shard?.txt file")
+    assert os.path.isfile(args.rclone_config_path), "given rclone config file path is not a file"
+    assert re.match(r".*:.*", args.snapshot_bin), "given snapshot bin does not follow format: <rclone-config>:<bin>"
 
 
 def _parse_args():
     """
-    Argument parser that is only used for main execution of this script.
+    Argument parser that is only used for main execution.
     """
-    parser = argparse.ArgumentParser(description='Snapshot script to be ran from command machine')
-    default_config_path = f"{script_directory}/config.json"
-    parser.add_argument("--config", type=str, default=default_config_path,
-                        help=f"path to snapshot config (default {default_config_path})")
-    parser.add_argument("--bucket-sync", action='store_true',
-                        help="Enable syncing to external bucket (where bucket is defined in the config)")
-    args = parser.parse_args()
-    return _get_ips_per_shard(args), args
+    if 'HMY_PROFILE' not in os.environ:
+        raise SystemExit("HMY_PROFILE not set, exiting...")
+    parser = argparse.ArgumentParser(description='Snapshot recovery script')
+    parser.add_argument("network", type=str, help=f"{supported_networks}")
+    default_log_dir = f"{script_directory}/logs/{os.environ['HMY_PROFILE']}"
+    parser.add_argument("--logs-dir", type=str,
+                        help="the logs directory containing the shard?.txt files needed to ssh into the machines, "
+                             f"default is '{default_log_dir}'")
+    default_rclone_config_path = f"{script_directory}/../tools/snapshot/rclone.conf"
+    parser.add_argument("--rclone-config-path", type=str, default=default_rclone_config_path,
+                        help="path to rclone config to download the snapshot db, "
+                             f"default is '{default_rclone_config_path}'")
+    parser.add_argument("--snapshot-bin", type=str, default=f"snapshot:harmony-snapshot",
+                        help="the rclone config name (based on `--rclone-config`) and bin to download the snapshot db, "
+                             "default is 'snapshot:harmony-snapshot'")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args()
 
 
-if __name__ == "__name__":
+if __name__ == "__main__":
     assert pyhmy.__version__.major == 20
     assert pyhmy.__version__.minor >= 5
     assert pyhmy.__version__.micro >= 5
-    ips_per_shard, args = _parse_args()
-    setup_logger()
+    args = _parse_args()
+    _assumption_check(args)
+    if args.verbose:
+        setup_logger(do_print=True)
+    ips_per_shard = _get_ips_per_shard(args)
     reset_dbs_interactively(ips_per_shard)
     restart_and_check(ips_per_shard)
     log.debug("finished recovery")

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -17,7 +17,14 @@ Note that explorer nodes are recovered with a non-archival db.
 Manual archival recovery will need to be afterwards.
 
 Example Usage:
-    TODO: example
+    python3 snapshot_recovery.py testnet
+    python3 snapshot_recovery.py mainnet --verbose
+    python3 snapshot_recovery.py testnet --log-dir /some/path/here/
+    python3 snapshot_recovery.py testnet --rcone-config-path /some/path/rclone.conf
+    python3 snapshot_recovery.py testnet --snapshot-bin "snapshot:harmony-snapshot"
+
+Help + Descriptions and default values:
+    python3 snapshot_recovery.py --help
 """
 
 import time

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -31,7 +31,6 @@ import time
 import argparse
 import subprocess
 import os
-import json
 import logging
 import traceback
 import re
@@ -500,13 +499,14 @@ def recover(ips_per_shard, snapshot_per_shard, rclone_config_path):
 
     _interaction_lock.acquire()
     try:
+        print()
         for shard in sorted(ips_per_shard.keys()):
-            print(f"{Typgpy.BOLD}Shard {Typgpy.HEADER}{shard}{Typgpy.ENDC}{Typgpy.BOLD} IPs:")
+            print(f"{Typgpy.BOLD}Shard {Typgpy.HEADER}{shard}{Typgpy.ENDC}{Typgpy.BOLD} IPs: {Typgpy.ENDC}")
             for i, ip in enumerate(ips_per_shard[shard]):
                 print(f"{i}.\t{Typgpy.OKGREEN}{ip}{Typgpy.ENDC}")
-            print(f"{Typgpy.BOLD}Shard {Typgpy.HEADER}{shard}{Typgpy.ENDC}{Typgpy.BOLD} snapshot path: "
+            print(f"{Typgpy.BOLD}Shard {Typgpy.HEADER}{shard}{Typgpy.ENDC}{Typgpy.BOLD} snapshot path: {Typgpy.ENDC}"
                   f"{Typgpy.OKGREEN}{snapshot_per_shard[shard]}{Typgpy.ENDC}")
-        print()
+            print()
         print(f"{Typgpy.BOLD}Rclone config path (on this machine): "
               f"{Typgpy.OKGREEN}{rclone_config_path}{Typgpy.ENDC}")
         if interact("Start recovery?", ["yes", "no"]) == "no":

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -21,11 +21,9 @@ Example Usage:
 """
 
 import time
-import datetime
 import argparse
 import subprocess
 import os
-import sys
 import json
 import logging
 import traceback
@@ -493,7 +491,19 @@ def recover(ips_per_shard, snapshot_per_shard, rclone_config_path):
     assert beacon_chain_shard in snapshot_per_shard.keys()
     assert os.path.isfile(rclone_config_path)
 
-    # TODO: print current config (ips, snapshot bin and rclone config) and ask for confirmation...
+    _interaction_lock.acquire()
+    try:
+        for shard in sorted(ips_per_shard.keys()):
+            print(f"{Typgpy.BOLD}Shard {Typgpy.HEADER}{shard}{Typgpy.BOLD} IPs:")
+            for i, ip in enumerate(ips_per_shard[shard]):
+                print(f"{i}.\t{Typgpy.OKGREEN}{ip}{Typgpy.ENDC}")
+            print(f"{Typgpy.BOLD}Shard {Typgpy.HEADER}{shard}{Typgpy.BOLD} snapshot path: "
+                  f"{Typgpy.OKGREEN}{snapshot_per_shard[shard]}{Typgpy.ENDC}")
+        if interact("Start recovery?", ["yes", "no"]) == "no":
+            log.warning("Abandoned recovery...")
+            return
+    finally:
+        _interaction_lock.release()
 
     def process(shard):
         ips = ips_per_shard[shard]

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -5,10 +5,10 @@ Recover a network using a given snapshot.
 
 Note that this script has assumptions regarding its path and relies
 on the rest of the repository being cloned. Here are the assumptions:
-* node_ssh.sh needs to be in the current working directory and never requires interaction.
-* $(pwd)/../tools/snapshot/rclone.conf contains the default rclone config for
+* node_ssh.sh needs to be in the same directory as the script and never requires interaction.
+* <script-directory>/../tools/snapshot/rclone.conf contains the default rclone config for
   a node to download the snapshot db.
-* $(pwd)/utils/scripting.py is a python3 library
+* <script-directory>/utils/scripting.py is a python3 library
 * Assumes that the harmony process is ran as a service called `harmony`.
 
 Note that this script assumes that the given bin is accessible from the machine it is running on.

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -208,9 +208,10 @@ def _backup_existing_dbs(ip, shard):
 
     Returns None if done successfully, otherwise returns string with error msg.
     """
-    log.debug(f"backing up node {ip}")
-    cmd = f"[ ! pgrep harmony ] && tar -czf harmony_db_0.tar.gz {db_directory_on_machine}/harmony_db_0 "
-    cmd += f"& [ ! pgrep harmony ] && tar -czf harmony_db_{shard}.tar.gz {db_directory_on_machine}/harmony_db_{shard}"
+    unix_time = int(time.time())
+    log.debug(f"backing up node {ip} at unix time: {unix_time}")
+    cmd = f"[ ! pgrep harmony ] && tar -czf harmony_db_0.{unix_time}.tar.gz {db_directory_on_machine}/harmony_db_0 "
+    cmd += f"& [ ! pgrep harmony ] && tar -czf harmony_db_{shard}.{unix_time}.tar.gz {db_directory_on_machine}/harmony_db_{shard}"
     try:
         _ssh_cmd(ip, cmd)
         return None  # indicate success

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -3,6 +3,12 @@
 """
 Recover a network using a given snapshot.
 
+Note that this script has assumptions regarding its path and relies
+on the rest of the repository being cloned. Here are the assumptions:
+* node_ssh.sh needs to be in the current working directory and never requires interaction.
+* $(pwd)/../tools/snapshot/rclone.conf contains the default rclone config for
+  a node to download the snapshot db.
+
 Note that explorer nodes are recovered with a non-archival db.
 Manual archival recovery will need to be afterwards.
 

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -982,9 +982,9 @@ def get_snapshot_per_shard(network, ips_per_shard, snapshot_config_bin):
                                          prefill=f"{snapshot_bin}")
                 log.debug(f"chose DB: {snapshot} for shard {shard}")
                 try:
-                    assert len(aws_s3_ls(snapshot)) > 0, f"given snapshot bin '{snapshot}' is empty"
+                    aws_s3_ls(snapshot)
                     break
-                except (subprocess.CalledProcessError, AssertionError) as e:
+                except subprocess.CalledProcessError as e:
                     error_msg = f"Machine is unable to list s3 files at '{snapshot}'. Error: {e}"
                     print(error_msg)
                     log.error(traceback.format_exc())

--- a/pipeline/snapshot_recover.py
+++ b/pipeline/snapshot_recover.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Recover a network using a given snapshot.
+
+Note that explorer nodes are recovered with a non-archival db.
+Manual archival recovery will need to be afterwards.
+
+Example Usage:
+    TODO: example
+"""
+
+import argparse
+import logging
+import sys
+import time
+from multiprocessing.pool import ThreadPool
+
+import pyhmy
+from pyhmy import (
+    blockchain,
+    rpc,
+    Typgpy
+)
+
+
+pyhmy_version = '20.5.3'
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Recover snapshot script to be ran from devops machine')
+    parser.add_argument("log_dir", type=str, help="Path to the log directory that contains the networks's shard?.txt files.")
+    parser.add_argument("--network", type=str, default="mainnet", help="Network type (default: mainnet)")
+    parser.add_argument("--shard", type=str, default="0,1,2,3",
+                        help="String in CSV format of shards to recover, default is '0,1,2,3'")
+    return parser.parse_args()
+
+
+def setup_logger():
+    logger = logging.getLogger("snapshot")
+    file_handler = logging.FileHandler(f"{args.log_dir}/recover_from_snapshot.log")
+    file_handler.setFormatter(logging.Formatter(f"{Typgpy.OKGREEN}[%(asctime)s]{Typgpy.ENDC} %(message)s"))
+    logger.addHandler(file_handler)
+    logger.addHandler(logging.StreamHandler(sys.stdout))
+    logger.setLevel(logging.DEBUG)
+    print(f"Log file saved to: {args.log_dir}/recover_from_snapshot.log")
+    return logger
+
+
+def process_args():
+    return {}, args.network
+
+
+def select_snapshot():
+    """
+    Interactively select the snapshot to ensure security
+    """
+    pass
+
+
+def backup_existing_dbs(ips, shard):
+    """
+    Simply tar the existing db if needed in the future
+    """
+    pass
+
+
+def rsync_recovered_dbs(ips, shard):
+    """
+    Assumption is that nodes have rclone setup with appropriate credentials.
+    """
+    pass
+
+
+def reset_dbs_interactively():
+    """
+    Bulk of the work is handled here.
+    Actions done interactively to ensure security.
+    Done it batches with confirmation for security.
+    """
+    pass
+
+
+def restart_all(ips):
+    """
+    Send restart command to all nodes asynchronously.
+    """
+    pass
+
+
+def verify_all_started(ips):
+    """
+    Verify all nodes started asynchronously.
+    """
+    pass
+
+
+def verify_all_progressed(ips):
+    """
+    Verify all nodes progressed asynchronously.
+    """
+    pass
+
+
+def restart_and_check():
+    """
+    Main restart and verification function after DBs have been restored.
+    """
+    threads = []
+    post_check_pool = ThreadPool()
+    for shard in ips_for_shard.keys():
+        log.debug(f"starting restart for shard {shard}; ips: {ips_for_shard[shard]}")
+        threads.append(post_check_pool.apply_async(restart_all, (ips_for_shard[shard],)))
+    for t in threads:
+        t.get()
+    log.debug(f"finished restarting shards {sorted(ips_for_shard.keys())}")
+
+    sleep_b4_running_check = 10
+    log.debug(f"sleeping {sleep_b4_running_check} seconds before checking if all nodes started")
+    time.sleep(sleep_b4_running_check)
+
+    threads = []
+    for shard in ips_for_shard.keys():
+        log.debug(f"starting node restart verification for shard {shard}; ips: {ips_for_shard[shard]}")
+        threads.append(post_check_pool.apply_async(verify_all_started, (ips_for_shard[shard],)))
+    if not all(t.get() for t in threads):
+        raise SystemExit(f"not all nodes restarted, check logs for details: "
+                         f"{args.log_dir}/recover_from_snapshot.log")
+
+    sleep_b4_progress_check = 30
+    log.debug(f"sleeping {sleep_b4_progress_check} seconds before checking if all nodes are making progress")
+    time.sleep(sleep_b4_progress_check)
+
+    threads = []
+    for shard in ips_for_shard.keys():
+        log.debug(f"starting node progress verification for shard {shard}; ips: {ips_for_shard[shard]}")
+        threads.append(post_check_pool.apply_async(verify_all_progressed, (ips_for_shard[shard],)))
+    if not all(t.get() for t in threads):
+        raise SystemExit(f"not all nodes made progress, check logs for details: "
+                         f"{args.log_dir}/recover_from_snapshot.log")
+    log.debug("recovery succeeded!")
+
+
+if __name__ == "__name__":
+    assert pyhmy.__version__.public() == pyhmy_version, f'install correct pyhmy version with `python3 -m pip install pyhmy=={pyhmy_version}`'
+    log, args = setup_logger(), parse_args()
+    ips_for_shard, network = process_args()
+    reset_dbs_interactively()
+    if input(f"Restart shards {sorted(ips_for_shard.keys())}? [Y/n]\n> ").lower() in {'yes', 'y'}:
+        restart_and_check()
+    log.debug("finished recovery")

--- a/pipeline/utils/scripting.py
+++ b/pipeline/utils/scripting.py
@@ -2,6 +2,7 @@ import subprocess
 import os
 import sys
 import logging
+import readline
 
 from pyhmy.util import (
     Typgpy
@@ -75,6 +76,19 @@ def interact(prompt, selection_list, sort=True):
             return selection_list[n]
         except ValueError:
             pass
+
+
+def input_prefill(prompt, prefill=''):
+    """
+    Read an input with some prefilled data.
+
+    Note that this only works on Unix based systems.
+    """
+    readline.set_startup_hook(lambda: readline.insert_text(prefill))
+    try:
+        return input(prompt)
+    finally:
+        readline.set_startup_hook()
 
 
 def aws_s3_ls(path):

--- a/pipeline/utils/scripting.py
+++ b/pipeline/utils/scripting.py
@@ -1,0 +1,89 @@
+import subprocess
+import os
+import sys
+import logging
+
+from pyhmy.util import (
+    Typgpy
+)
+
+ipv4_regex = r"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+
+
+def setup_logger(log_file, logger_name, do_print=True, verbose=True):
+    """
+    Setup the logger for the snapshot package and returns the logger.
+    """
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    logger = logging.getLogger(logger_name)
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(
+        logging.Formatter(f"(%(threadName)s)[%(asctime)s] %(message)s"))
+    logger.addHandler(file_handler)
+    if do_print:
+        logger.addHandler(logging.StreamHandler(sys.stdout))
+    logger.setLevel(logging.DEBUG)
+    logger.debug("===== NEW LOG =====")
+    if verbose:
+        print(f"Logs saved to: {log_file}")
+    return logger
+
+
+def interact(prompt, selection_list, sort=True):
+    """
+    Prompt the user with `prompt` and an enumerated selection from a possibly sorted `selection_list`.
+    Take in an integer, n, such that 0 <= n < len(`selection_list`).
+    If a `log` is provided, log the interaction and all errors at the info and error level respectively.
+
+    Keeps prompting user for input if input is invalid.
+    Prints user interaction before returning.
+
+    Note that all new lines from `prompt` and `selection_list` will be removed.
+
+    Returns n and corresponding selection string from `selection_list`.
+    """
+    if not selection_list:
+        return
+    input_prompt = f"{Typgpy.BOLD}Select option (number):{Typgpy.ENDC}\n> "
+
+    prompt, selection_list = prompt.replace("\n", ""), [e.replace("\n", "") for e in selection_list]
+    if sort:
+        selection_list = sorted(selection_list, reverse=True)
+    prompt_new_line_count = sum(1 for el in selection_list if el) + 3  # 1 for given prompt, 2 for input prompt
+    if prompt:
+        prompt_new_line_count += 1
+    printed_new_line_count = 0
+    print()
+
+    while True:
+        if prompt:
+            print(prompt)
+        for i, selection in enumerate(selection_list):
+            print(f"{Typgpy.BOLD}[{i}]{Typgpy.ENDC}\t{selection}")
+        user_input = input(input_prompt)
+        printed_new_line_count += prompt_new_line_count
+        try:
+            n = int(user_input)
+            if n >= len(selection_list):
+                continue
+            selection_report = f"{prompt} {Typgpy.BOLD}[{n}]{Typgpy.ENDC} {selection_list[n]}".strip()
+            for i in range(printed_new_line_count):
+                sys.stdout.write("\033[K")
+                if i + 1 < printed_new_line_count:
+                    sys.stdout.write("\033[F")
+            print(selection_report)
+            return selection_list[n]
+        except ValueError:
+            pass
+
+
+def aws_s3_ls(path):
+    """
+    AWS command to list contents of an s3 bucket anonymously.
+    Assumes AWS CLI is setup on machine.
+
+    Raises subprocess.CalledProcessError if aws command fails.
+    """
+    cmd = ['aws', 's3', 'ls', path]
+    return [n.replace('PRE', '').replace("/", "").strip() for n in
+            subprocess.check_output(cmd, env=os.environ, timeout=60).decode().split("\n") if "PRE" in n]


### PR DESCRIPTION
This closes https://github.com/harmony-one/harmony/issues/2998

## Recovery design
* [One script](https://github.com/harmony-one/experiment-deploy/blob/snapshot-recovery/pipeline/snapshot_recover.py) to execute the recovery.
* All actions are prompted for confirmation before executing (with no bypass).
* IPs are loaded via an optioned logs-directory (i.e: `./logs/s3/`). However, the script will ask for confirmation on the loaded IPs.
* The script will allow the user to choose a subset of loaded IPs (for each shard) and/or a subset of shard(s). Alternatively, a user can manually enter IPs for each shard as a CSV string of IPs. 
* The user can manually enter the s3 bucket path for the snapshot DB that they would like to recovery with (for each shard's DB), or they can interactively choose the DBs from a list of snapshots sorted in descending order by block. 
* The script will ALWAYS backup existing DB on ALL nodes (locally) before recovering from a snapshot.
* The user can choose to restart all of the given/selected IPs after recovery & check for a running node with progress

**The script will use some assumptions given by the nature of being in the `pipeline`**. That said, the script makes such assumptions in contained units, therefore minimal edits would be needed should such assumpts be no longer valid. **Here are the assumptions:**
> * node_ssh.sh needs to be in the same directory as the script and never requires interaction.
> * <script-directory>/../tools/snapshot/rclone.conf contains the default rclone config for
>   a node to download the snapshot db.
> * <script-directory>/utils/scripting.py is a python3 library

Internally [here is the doc](https://app.gitbook.com/@harmony-one/s/onboarding-wiki/devops-run-book/harmony-snapshot/recovering-nodes).